### PR TITLE
Implement simple bytecode compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,10 @@ thiserror = "1.0"
 # JSON support
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+```
+
+## Bytecode Compiler
+
+The compiler transforms parsed AST nodes into a simple bytecode which is then
+executed by a tiny virtual machine. Running `cargo run` will start the REPL
+using this compiler.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,6 +1,12 @@
-/// AST node types for Pickup
-#[derive(Debug)]
+/// Abstract syntax tree node types for Pickup.
+#[derive(Debug, Clone)]
 pub enum AstNode {
-    // TODO: define expressions, statements, function defs, etc.
+    /// Top level program consisting of a list of statements/expressions.
     Program(Vec<AstNode>),
+    /// Numeric literal.
+    Number(f64),
+    /// String literal.
+    String(String),
+    /// Identifier token.
+    Identifier(String),
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,0 +1,56 @@
+use crate::ast::AstNode;
+
+/// Bytecode instructions for the Pickup VM.
+#[derive(Debug, Clone)]
+pub enum Instruction {
+    PushNumber(f64),
+    PushString(String),
+    PushIdentifier(String),
+    Print,
+}
+
+/// Compile an AST to bytecode instructions.
+pub struct Compiler;
+
+impl Compiler {
+    pub fn compile(ast: &AstNode) -> Vec<Instruction> {
+        let mut code = Vec::new();
+        Self::compile_node(ast, &mut code);
+        code
+    }
+
+    fn compile_node(node: &AstNode, code: &mut Vec<Instruction>) {
+        match node {
+            AstNode::Program(stmts) => {
+                for stmt in stmts {
+                    Self::compile_node(stmt, code);
+                    code.push(Instruction::Print);
+                }
+            }
+            AstNode::Number(n) => code.push(Instruction::PushNumber(*n)),
+            AstNode::String(s) => code.push(Instruction::PushString(s.clone())),
+            AstNode::Identifier(id) => code.push(Instruction::PushIdentifier(id.clone())),
+        }
+    }
+}
+
+/// Simple bytecode interpreter.
+pub struct Vm;
+
+impl Vm {
+    pub fn execute(code: &[Instruction]) {
+        let mut stack: Vec<String> = Vec::new();
+        for inst in code {
+            match inst {
+                Instruction::PushNumber(n) => stack.push(n.to_string()),
+                Instruction::PushString(s) => stack.push(s.clone()),
+                Instruction::PushIdentifier(id) => stack.push(format!("<{}>", id)),
+                Instruction::Print => {
+                    if let Some(val) = stack.pop() {
+                        println!("{}", val);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ mod cli;
 mod repl;
 mod parser;
 mod ast;
-mod interpreter;
+mod compiler;
 
 fn main() {
     let args = cli::parse_args();
@@ -11,8 +11,8 @@ fn main() {
         let source = std::fs::read_to_string(path).expect("Failed to read script");
         let tokens = parser::tokenize(&source).expect("Lex error");
         let ast = parser::parse_to_ast(tokens).expect("Parse error");
-        let mut interp = interpreter::Interpreter::new();
-        interp.run_ast(&ast);
+        let bytecode = compiler::Compiler::compile(&ast);
+        compiler::Vm::execute(&bytecode);
     } else {
         // REPL path
         repl::run_repl();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -19,6 +19,40 @@ pub fn tokenize(source: &str) -> Result<pest::iterators::Pairs<Rule>, ParseError
 }
 
 pub fn parse_to_ast(pairs: pest::iterators::Pairs<Rule>) -> Result<AstNode, ParseError> {
-    // TODO: walk Pairs and build AST
-    unimplemented!()
+    fn build_expr(pair: pest::iterators::Pair<Rule>) -> Result<AstNode, ParseError> {
+        match pair.as_rule() {
+            Rule::number => {
+                let n: f64 = pair.as_str().parse().map_err(|e| {
+                    ParseError::AstError(format!("invalid number: {}", e))
+                })?;
+                Ok(AstNode::Number(n))
+            }
+            Rule::string => {
+                let s = pair.as_str();
+                // Trim the surrounding quotes
+                let inner = &s[1..s.len() - 1];
+                Ok(AstNode::String(inner.to_string()))
+            }
+            Rule::identifier => Ok(AstNode::Identifier(pair.as_str().to_string())),
+            _ => Err(ParseError::AstError(format!(
+                "unexpected rule: {:?}",
+                pair.as_rule()
+            ))),
+        }
+    }
+
+    let mut stmts = Vec::new();
+    for pair in pairs {
+        match pair.as_rule() {
+            Rule::statement => {
+                let expr_pair = pair.into_inner().next().ok_or_else(|| {
+                    ParseError::AstError("empty statement".into())
+                })?;
+                stmts.push(build_expr(expr_pair)?);
+            }
+            Rule::EOI => {}
+            _ => {}
+        }
+    }
+    Ok(AstNode::Program(stmts))
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,16 +1,18 @@
 use rustyline::Editor;
-use crate::{parser, interpreter};
+use crate::{parser, compiler};
 
 pub fn run_repl() {
     let mut rl = Editor::<()>::new();
-    let mut interp = interpreter::Interpreter::new();
     println!("Pickup REPL (type 'exit' or Ctrl+C to quit)");
     loop {
         let line = rl.readline(">>> ").unwrap_or_else(|_| String::new());
         if line.trim() == "exit" { break; }
         rl.add_history_entry(&line);
         match parser::tokenize(&line).and_then(|t| parser::parse_to_ast(t)) {
-            Ok(ast) => interp.run_ast(&ast),
+            Ok(ast) => {
+                let code = compiler::Compiler::compile(&ast);
+                compiler::Vm::execute(&code);
+            }
             Err(e) => eprintln!("Error: {}", e),
         }
     }


### PR DESCRIPTION
## Summary
- extend AST node definitions
- implement AST parsing
- add a basic bytecode compiler and VM
- run compiled bytecode in main program and REPL
- document the compiler in the README

## Testing
- `cargo check` *(fails: could not download crates)*
- `cargo fmt` *(fails: rustfmt not installed)*